### PR TITLE
29 automatically build application

### DIFF
--- a/.github/workflows/development-build.yml
+++ b/.github/workflows/development-build.yml
@@ -1,0 +1,36 @@
+name: EAS Development Build
+on:
+  push:
+    branches:
+      - dev
+jobs:
+  build:
+    name: Install and build
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🏗 Setup repo
+        uses: actions/checkout@v3
+
+      - name: 🏗 Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          cache: npm
+
+      - name: 🏗 Setup Expo and EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: 📦 Install dependencies
+        run: npm ci
+
+      - name: ⚒️ Build on EAS
+        run: eas build --platform android --profile development --local
+
+      - name: ⬆️Upload a Build Artifact
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: dev-build
+          path: /home/runner/work/klinks/klinks/build-*.apk

--- a/.github/workflows/development-build.yml
+++ b/.github/workflows/development-build.yml
@@ -5,7 +5,7 @@ on:
       - dev
 jobs:
   build:
-    name: Install and build
+    name: Install, build and upload
     runs-on: ubuntu-latest
     steps:
       - name: 🏗 Setup repo

--- a/.github/workflows/development-build.yml
+++ b/.github/workflows/development-build.yml
@@ -32,5 +32,5 @@ jobs:
       - name: ⬆️Upload a Build Artifact
         uses: actions/upload-artifact@v3.1.2
         with:
-          name: dev-build
-          path: /home/runner/work/klinks/klinks/development-build-*.apk
+          name: development-build
+          path: /home/runner/work/klinks/klinks/build-*.apk

--- a/.github/workflows/development-build.yml
+++ b/.github/workflows/development-build.yml
@@ -33,4 +33,4 @@ jobs:
         uses: actions/upload-artifact@v3.1.2
         with:
           name: dev-build
-          path: /home/runner/work/klinks/klinks/build-*.apk
+          path: /home/runner/work/klinks/klinks/development-build-*.apk

--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -22,3 +22,6 @@ jobs:
         run: eas build --platform android --profile development --local
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v3.1.2
+        with:
+          name: dev-build
+          path: /home/runner/work/klinks/klinks/build-*.apk

--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -20,3 +20,5 @@ jobs:
         run: npm ci
       - name: Build on EAS
         run: eas build --platform android --profile development --local
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v3.1.2

--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -1,0 +1,22 @@
+name: EAS Build
+on:
+  push
+jobs:
+  build:
+    name: Install and build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          cache: npm
+      - name: Setup Expo and EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+      - name: Install dependencies
+        run: npm ci
+      - name: Build on EAS
+        run: eas build --platform android --profile development --local

--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -6,21 +6,28 @@ jobs:
     name: Install and build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - name: 🏗 Setup repo
+        uses: actions/checkout@v3
+
+      - name: 🏗 Setup Node
+        uses: actions/setup-node@v3
         with:
           node-version: 18.x
           cache: npm
-      - name: Setup Expo and EAS
+
+      - name: 🏗 Setup Expo and EAS
         uses: expo/expo-github-action@v8
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
-      - name: Install dependencies
+
+      - name: 📦 Install dependencies
         run: npm ci
-      - name: Build on EAS
+
+      - name: ⚒️ Build on EAS
         run: eas build --platform android --profile development --local
-      - name: Upload a Build Artifact
+
+      - name: ⬆️Upload a Build Artifact
         uses: actions/upload-artifact@v3.1.2
         with:
           name: dev-build

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -2,7 +2,7 @@ name: EAS Preview Build
 on: [pull_request]
 jobs:
   build:
-    name: Install and build
+    name: Install, build and upload
     runs-on: ubuntu-latest
     steps:
       - name: 🏗 Setup repo

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -1,0 +1,33 @@
+name: EAS Preview Build
+on: [pull_request]
+jobs:
+  build:
+    name: Install and build
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🏗 Setup repo
+        uses: actions/checkout@v3
+
+      - name: 🏗 Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          cache: npm
+
+      - name: 🏗 Setup Expo and EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: 📦 Install dependencies
+        run: npm ci
+
+      - name: ⚒️ Build on EAS
+        run: eas build --platform android --profile preview --local
+
+      - name: ⬆️Upload a Build Artifact
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: preview-build
+          path: /home/runner/work/klinks/klinks/build-*.apk

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -5,7 +5,7 @@ on:
       - main
 jobs:
   build:
-    name: Install and build
+    name: Install, build and submit
     runs-on: ubuntu-latest
     steps:
       - name: 🏗 Setup repo
@@ -33,5 +33,5 @@ jobs:
         env:
           PLAY_CONFIG_JSON: ${{ secrets.GOOGLE_SERVICES_ACCOUNT_KEY_JSON }}
 
-      - name: ⚒️ Build on EAS
+      - name: ⚒️ Build on EAS and auto submit
         run: eas build --platform android --profile production --auto-submit --local

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -33,4 +33,4 @@ jobs:
         uses: actions/upload-artifact@v3.1.2
         with:
           name: dev-build
-          path: /home/runner/work/klinks/klinks/build-*.apk
+          path: /home/runner/work/klinks/klinks/production-build-*.apk

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -32,5 +32,5 @@ jobs:
       - name: ⬆️Upload a Build Artifact
         uses: actions/upload-artifact@v3.1.2
         with:
-          name: dev-build
-          path: /home/runner/work/klinks/klinks/production-build-*.apk
+          name: production-build
+          path: /home/runner/work/klinks/klinks/build-*.apk

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -26,11 +26,12 @@ jobs:
       - name: 📦 Install dependencies
         run: npm ci
 
-      - name: ⚒️ Build on EAS
-        run: eas build --platform android --profile production --local
+      - name: 🔐 Create Google Play Service Account key file
+        run: |
+          echo "GOOGLE_SERVICES_ACCOUNT_KEY_JSON" > google_services_account_key.json.b64
+          base64 -d -i google_services_account_key.json.b64 > google_services_account_key.json
+        env:
+          PLAY_CONFIG_JSON: ${{ secrets.GOOGLE_SERVICES_ACCOUNT_KEY_JSON }}
 
-      - name: ⬆️Upload a Build Artifact
-        uses: actions/upload-artifact@v3.1.2
-        with:
-          name: production-build
-          path: /home/runner/work/klinks/klinks/build-*.apk
+      - name: ⚒️ Build on EAS
+        run: eas build --platform android --profile production --auto-submit --local

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -1,6 +1,8 @@
-name: EAS Build
+name: EAS Production Build
 on:
-  push
+  push:
+    branches:
+      - main
 jobs:
   build:
     name: Install and build
@@ -25,7 +27,7 @@ jobs:
         run: npm ci
 
       - name: ⚒️ Build on EAS
-        run: eas build --platform android --profile development --local
+        run: eas build --platform android --profile production --local
 
       - name: ⬆️Upload a Build Artifact
         uses: actions/upload-artifact@v3.1.2

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ web-build/
 
 # IDE
 .idea
+
+# APKs
+*.apk

--- a/eas.json
+++ b/eas.json
@@ -27,6 +27,11 @@
     }
   },
   "submit": {
-    "production": {}
+    "production": {
+      "android": {
+        "serviceAccountKeyPath": "google_services_account_key.json",
+        "track": "internal"
+      }
+    }
   }
 }


### PR DESCRIPTION
App should now:
- Build preview build on pull requests.
- Build development build on pushes to dev branch.
- Build and submit to Play Store on pushes to main.
All builds except production should be downloadable from GitHub Actions.

Had to add secret for Google Services Account key.